### PR TITLE
Replace Qt file APIs in parsers

### DIFF
--- a/src/parser/odbpp/notesparser.cpp
+++ b/src/parser/odbpp/notesparser.cpp
@@ -22,7 +22,8 @@
 
 #include "notesparser.h"
 
-#include <QtCore>
+#include <fstream>
+#include <string>
 
 NotesParser::NotesParser(const QString& filename): Parser(filename)
 {
@@ -34,15 +35,26 @@ NotesParser::~NotesParser()
 
 NotesDataStore* NotesParser::parse(void)
 {
-  QFile file(m_fileName);
-  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+#ifdef _WIN32
+  std::wifstream file(m_fileName.toStdWString());
+#else
+  std::ifstream file(m_fileName.toStdString());
+#endif
+  if (!file.is_open()) {
     qDebug("parse: can't open `%s' for reading", qPrintable(m_fileName));
     return NULL;
   }
 
   NotesDataStore* ds = new NotesDataStore;
-  while (!file.atEnd()) {
-    QString line = file.readLine();
+#ifdef _WIN32
+  std::wstring wline;
+  while (std::getline(file, wline)) {
+    QString line = QString::fromStdWString(wline);
+#else
+  std::string sline;
+  while (std::getline(file, sline)) {
+    QString line = QString::fromStdString(sline);
+#endif
     ds->putRecord(line.split(","));
   }
 

--- a/src/parser/odbpp/structuredtextparser.cpp
+++ b/src/parser/odbpp/structuredtextparser.cpp
@@ -23,7 +23,8 @@
 #include "structuredtextparser.h"
 
 #include <QDebug>
-#include <QSysInfo>
+#include <fstream>
+#include <string>
 
 #include "yyheader.h"
 #include "db.tab.h"
@@ -46,18 +47,11 @@ StructuredTextParser::~StructuredTextParser()
 
 StructuredTextDataStore* StructuredTextParser::parse(void)
 {
-#ifdef Q_OS_WIN
-  if (QSysInfo::WindowsVersion == QSysInfo::WV_XP) {
-    wchar_t buf[BUFSIZ];
-    memset(buf, 0, sizeof(wchar_t) * BUFSIZ);
-    m_fileName.toWCharArray(buf);
-
-    yyin = _wfopen(buf, (const wchar_t*)"r");
-  } else {
-    yyin = fopen(m_fileName.toLatin1(), "r");
-  }
+#ifdef _WIN32
+  std::wstring wpath = m_fileName.toStdWString();
+  yyin = _wfopen(wpath.c_str(), L"r");
 #else
-  yyin = fopen(m_fileName.toLatin1(), "r");
+  yyin = fopen(m_fileName.toStdString().c_str(), "r");
 #endif
 
   if (yyin == NULL) {


### PR DESCRIPTION
## Summary
- remove usage of QFile, QSysInfo
- use standard `std::(w)ifstream` for reading
- rely on `std::wstring` when compiling on Windows

## Testing
- `make -n` *(fails: "No targets specified and no makefile found")*

------
https://chatgpt.com/codex/tasks/task_e_68479b0da204832cb2af64acf990b2d0