### PR TITLE
Enable Qt build and UNICODE

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 REQUIRED COMPONENTS Widgets)
+
+add_definitions(-DUNICODE -D_UNICODE)
+
 # Collect common source files
 file(GLOB_RECURSE COMMON_SOURCES
     archiveloader.cpp
@@ -12,15 +20,18 @@ file(GLOB_RECURSE COMMON_SOURCES
     graphicsview/*.cpp
     gui/*.cpp
 )
+set(COMMON_SOURCES ${COMMON_SOURCES} resources.qrc)
 
 # qcamber executable
 set(QCAMBER_SOURCES ${COMMON_SOURCES} main.cpp)
 add_executable(qcamber ${QCAMBER_SOURCES})
+target_link_libraries(qcamber PRIVATE Qt5::Widgets)
 
 # test executable
 file(GLOB TEST_SOURCES tests/*.cpp)
 set(TEST_APP_SOURCES ${COMMON_SOURCES} ${TEST_SOURCES})
 add_executable(test ${TEST_APP_SOURCES})
+target_link_libraries(test PRIVATE Qt5::Widgets)
 
 if(WIN32)
     target_link_libraries(qcamber PRIVATE ws2_32)


### PR DESCRIPTION
## Summary
- configure CMake to find Qt5 and link Widgets
- enable automatic Qt processing and UNICODE

## Testing
- `cmake ..` *(fails: Could not find Qt5Config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_6847bef1c41c832c94c9024631b76720